### PR TITLE
Allow EOL to be passed at Call Time

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,14 @@
 var Transform = require('stream').Transform
 var util = require('util')
 var os = require('os')
-var EOL = os.EOL
 
 function Liner(opts) {
+  //set a default EOL per instance so it can change
+  this.EOL = os.EOL
   opts = opts || {}
   //accept EOL as an option instead of forcing the OS reported EOL
   if(opts.EOL){
-    EOL = opts.EOL
+    this.EOL = opts.EOL
     delete opts.EOL
   }
   opts.objectMode = true
@@ -20,7 +21,7 @@ Liner.prototype._transform = function transform(chunk, encoding, done) {
   if (this._lastLineData) {
     data = this._lastLineData + data
   }
-  var lines = data.split(EOL)
+  var lines = data.split(this.EOL)
   this._lastLineData = lines.splice(lines.length - 1, 1)[0]
 
   lines.forEach(this.push.bind(this))

--- a/index.js
+++ b/index.js
@@ -1,9 +1,15 @@
 var Transform = require('stream').Transform
 var util = require('util')
 var os = require('os')
+var EOL = os.EOL
 
 function Liner(opts) {
   opts = opts || {}
+  //accept EOL as an option instead of forcing the OS reported EOL
+  if(opts.EOL){
+    EOL = opts.EOL
+    delete opts.EOL
+  }
   opts.objectMode = true
   Transform.call(this, opts)
 }
@@ -14,7 +20,7 @@ Liner.prototype._transform = function transform(chunk, encoding, done) {
   if (this._lastLineData) {
     data = this._lastLineData + data
   }
-  var lines = data.split(os.EOL)
+  var lines = data.split(EOL)
   this._lastLineData = lines.splice(lines.length - 1, 1)[0]
 
   lines.forEach(this.push.bind(this))


### PR DESCRIPTION
This package shouldn't force the OS EOL; only default to it.

What I have proposed here should allow it to be set on a per instance level rather than any global setting so that I can do something like

```
var LinerStream = require('linerstream')
//use OS default
var stream1 = new LinerStream()
//force linux EOL
var stream2 = new LinerStream({EOL: '\n'})
//force windows EOL
var stream3 = new LinerStream({EOL: '\r\n'})
```
## Why

I need to be able to parse linux delimited files on Windows which shouldn't be all that unusual of a use case.
